### PR TITLE
Make cookie properties configurable

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,3 +1,6 @@
+cookie_name: record_id
+cookie_expiration: 120 # cookie lifetime in minutes
+
 tls_cert_file: server.crt
 tls_key_file: server.key
 

--- a/config/config.go
+++ b/config/config.go
@@ -9,11 +9,13 @@ import (
 
 // Config definition
 type Config struct {
-	TLSCertFile   string `yaml:"tls_cert_file"`
-	TLSKeyFile    string `yaml:"tls_key_file"`
-	Exporter      string
-	FileExporter  FileExporter  `yaml:"file_exporter,omitempty"`
-	RedisExporter RedisExporter `yaml:"redis_exporter,omitempty"`
+	RecordIdCookieName       string `yaml:"cookie_name"`
+	RecordIdCookieExpiration uint16 `yaml:"cookie_expiration"`
+	TLSCertFile              string `yaml:"tls_cert_file"`
+	TLSKeyFile               string `yaml:"tls_key_file"`
+	Exporter                 string
+	FileExporter             FileExporter  `yaml:"file_exporter,omitempty"`
+	RedisExporter            RedisExporter `yaml:"redis_exporter,omitempty"`
 }
 
 // FileExporter definition

--- a/testing/app_context.go
+++ b/testing/app_context.go
@@ -9,6 +9,8 @@ import (
 // CreateFileExporterAppContext creates a new *handlers.AppContext configured with FileExporter
 func CreateFileExporterAppContext() *handlers.AppContext {
 	appConfig := config.Config{
+		RecordIdCookieName: "record_id",
+		RecordIdCookieExpiration: 120,
 		Exporter: "file",
 		FileExporter: config.FileExporter{
 			Folder: "/tmp/test/track_entries",


### PR DESCRIPTION
New configuration properties:
```yaml
cookie_name: record_id
cookie_expiration: 120 # cookie lifetime in minutes
```

Next up, redis connection properties and prefix.